### PR TITLE
Update 1.21.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PurpurClient is designed to work together with [Purpur](https://github.com/Purpu
 
 </div>
 
-### Current Features in 1.21.3:
+### Current Features in 1.21.5:
 
 * Customizable mob passenger offsets
 * Adds bee counts inside beehives to debug screen¹

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'fabric-loom' version '1.8-SNAPSHOT'
+    id 'fabric-loom' version '1.10-SNAPSHOT'
     id "com.modrinth.minotaur" version "2.+"
 }
 
@@ -26,7 +26,7 @@ dependencies {
     minecraft("com.mojang:minecraft:${project.minecraft_version}")
     mappings loom.layered() {
         officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${minecraft_version}:${project.parchment_version}@zip")
+        //parchment("org.parchmentmc.data:parchment-${minecraft_version}:${project.parchment_version}@zip") // TODO: update when available
     }
     modImplementation("net.fabricmc:fabric-loader:${project.loader_version}")
     modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}")

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     // this is dumb as hell. bloats jar way too much. todo: switch to a different config provider
     include(modImplementation("org.spongepowered:configurate-hocon:${project.configurate_version}"))
     include("org.spongepowered:configurate-core:${project.configurate_version}")
-    include("com.google.guava:guava:33.3.0-jre")
+    include("com.google.guava:guava:33.4.5-jre")
     include("com.typesafe:config:1.4.3")
     include("io.leangen.geantyref:geantyref:1.3.16")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 minecraft_version=1.21.5-rc2
 loader_version=0.16.10
 # parchment_version=2025.02.16 # TODO: update when available
-fabric_version=0.119.4+1.21.5
+fabric_version=0.119.5+1.21.5
 modmenu_version=14.0.0-beta.2
 configurate_version=4.2.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.21.5-rc2
+minecraft_version=1.21.5
 loader_version=0.16.10
 # parchment_version=2025.02.16 # TODO: update when available
 fabric_version=0.119.5+1.21.5
-modmenu_version=14.0.0-beta.2
+modmenu_version=14.0.0-rc.1
 configurate_version=4.2.0
 
 maven_group=org.purpurmc.purpur.client

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.21.4
+minecraft_version=1.21.5-rc1
 loader_version=0.16.9
-parchment_version=2025.02.16
-fabric_version=0.110.5+1.21.4
-modmenu_version=13.0.0-beta.1
+# parchment_version=2025.02.16 # TODO: update when available
+fabric_version=0.119.3+1.21.5
+modmenu_version=14.0.0-beta.2
 configurate_version=4.1.2
 
 maven_group=org.purpurmc.purpur.client

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 
 minecraft_version=1.21.5-rc1
-loader_version=0.16.9
+loader_version=0.16.10
 # parchment_version=2025.02.16 # TODO: update when available
 fabric_version=0.119.3+1.21.5
 modmenu_version=14.0.0-beta.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx2G
 minecraft_version=1.21.5-rc1
 loader_version=0.16.10
 # parchment_version=2025.02.16 # TODO: update when available
-fabric_version=0.119.3+1.21.5
+fabric_version=0.119.4+1.21.5
 modmenu_version=14.0.0-beta.2
-configurate_version=4.1.2
+configurate_version=4.2.0
 
 maven_group=org.purpurmc.purpur.client
 archives_base_name=purpurclient

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.21.5-rc1
+minecraft_version=1.21.5-rc2
 loader_version=0.16.10
 # parchment_version=2025.02.16 # TODO: update when available
 fabric_version=0.119.4+1.21.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/purpurmc/purpur/client/gui/screen/MobScreen.java
+++ b/src/main/java/org/purpurmc/purpur/client/gui/screen/MobScreen.java
@@ -49,65 +49,65 @@ import net.minecraft.world.entity.monster.warden.Warden;
 
 public class MobScreen extends OptionsSubScreen {
     public static final Component TITLE = Component.translatable("purpurclient.options.title");
-    
+
     protected List<AbstractWidget> options;
     protected int centerX;
-    
+
     private final Mob mob;
     private final Component subtitle;
-    
+
     private FakePlayer fakePlayer;
     private Entity fakeEntity;
     private boolean alreadyInit;
-    
+
     private double mouseDownX = Double.MIN_VALUE;
     private double mouseDownY;
-    
+
     private double previewX = -80;
     private double previewY = 200;
     private float previewYaw = -145;
     private float previewPitch = -20;
     private float previewZoom = 60;
     private float previewZoomMultiplier = 1.0F;
-    
+
     private final Component noPreview = Component.translatable("purpurclient.options.no-preview");
     private final Component notImplemented = Component.translatable("purpurclient.options.not-implemented");
     private final Component experimentDisabled = Component.translatable("purpurclient.options.experiment-disabled");
-    
+
     public MobScreen(Screen parent, Mob mob) {
         super(parent, Minecraft.getInstance().options, TITLE);
         this.mob = mob;
         this.subtitle = Component.translatable("purpurclient.options.seat.title", mob.getType().getDescription());
     }
-    
+
     @Override
     public void init() {
         super.init();
         this.centerX = (int) (this.width / 2F);
-        
+
         final Seat seat = PurpurClient.instance().getConfig().seats.getSeat(this.mob);
-        
+
         this.options = new ArrayList<>();
         if (seat != null) {
             this.options.add(new DoubleButton(this.centerX + 70, 90, 100, 20, new DoubleOption("seat.x", () -> seat.x, (value) -> seat.x = value)));
             this.options.add(new DoubleButton(this.centerX + 70, 120, 100, 20, new DoubleOption("seat.y", () -> seat.y, (value) -> seat.y = value)));
             this.options.add(new DoubleButton(this.centerX + 70, 150, 100, 20, new DoubleOption("seat.z", () -> seat.z, (value) -> seat.z = value)));
         }
-        
+
         this.options.forEach(this::addRenderableWidget);
-        
+
         if (this.alreadyInit) {
             // we only need to set everything up once
             // not every time the window resizes
             return;
         }
         this.alreadyInit = true;
-        
+
         if (this.minecraft == null || this.minecraft.player == null) {
             // we need a client and player to draw a preview to...
             return;
         }
-        
+
         this.fakePlayer = new FakePlayer(this.minecraft.level, this.minecraft.player);
         this.fakeEntity = this.mob.getType().create(this.minecraft.level, EntitySpawnReason.NATURAL);
         if (this.fakeEntity == null) {
@@ -117,7 +117,7 @@ public class MobScreen extends OptionsSubScreen {
         }
         this.fakePlayer.setNoGravity(true);
         this.fakeEntity.setNoGravity(true);
-        
+
         // special cases
         if (this.fakeEntity instanceof Bat bat) {
             // wake bat up, no hanging upside down
@@ -146,15 +146,15 @@ public class MobScreen extends OptionsSubScreen {
         } else if (this.fakeEntity instanceof Slime slime) {
             ((AccessSlime) slime).invokeSetSize(3, true);
         }
-        
+
         // mount on the entity
         this.fakePlayer.startRiding(this.fakeEntity, true);
     }
-    
+
     @Override
     protected void addOptions() {
     }
-    
+
     @Override
     public void render(GuiGraphics context, int mouseX, int mouseY, float delta) {
         if (this.minecraft.level == null) {
@@ -173,7 +173,7 @@ public class MobScreen extends OptionsSubScreen {
                 context.drawCenteredString(this.font, this.noPreview, this.centerX - 80, 125, 0xFFFFFFFF);
             }
         }
-        
+
         PoseStack matrices = context.pose();
         matrices.pushPose();
         matrices.translate(0, 0, 900);
@@ -189,25 +189,25 @@ public class MobScreen extends OptionsSubScreen {
         matrices.popPose();
         context.fillGradient(0, 0, this.width, this.height, 0x800F4863, 0x80370038);
     }
-    
+
     @Override
     public void renderBackground(GuiGraphics context, int mouseX, int mouseY, float delta) {
         super.renderBackground(context, mouseX, mouseY, delta);
         context.fillGradient(0, 0, this.width, this.height, 0x800F4863, 0x80370038);
     }
-    
+
     public void drawPreviewModel(FakePlayer player, Entity vehicle) {
         Matrix4fStack matrixStack = RenderSystem.getModelViewStack();
         matrixStack.pushMatrix();
         matrixStack.translate((float) (this.centerX + this.previewX), (float) this.previewY, 1500);
         matrixStack.scale(1.0F, 1.0F, -1.0F);
-        
-        
+
+
         PoseStack matrixStack2 = new PoseStack();
         matrixStack2.translate(0.0D, 0.0D, 1000.0D);
         float zoom = this.previewZoom * this.previewZoomMultiplier;
         matrixStack2.scale(zoom, zoom, zoom);
-        
+
         Quaternionf quaternion = Axis.ZP.rotationDegrees(-180.0F);
         Quaternionf quaternion2 = Axis.XP.rotationDegrees(this.previewPitch);
         Quaternionf quaternion3 = Axis.YP.rotationDegrees(-this.previewYaw);
@@ -215,25 +215,25 @@ public class MobScreen extends OptionsSubScreen {
         quaternion.mul(quaternion2);
         quaternion2.conjugate();
         matrixStack2.mulPose(quaternion);
-        
+
         Lighting.setupForEntityInInventory();
         EntityRenderDispatcher renderer = Minecraft.getInstance().getEntityRenderDispatcher();
         renderer.overrideCameraOrientation(quaternion2);
         renderer.setRenderShadow(false);
         MultiBufferSource.BufferSource immediate = Minecraft.getInstance().renderBuffers().bufferSource();
-        
+
         Minecraft.getInstance().execute(() -> {
             fixEntityRender(vehicle, matrixStack2, () -> renderer.render(vehicle, vehicle.getX(), vehicle.getY(), vehicle.getZ(), 0.0F, matrixStack2, immediate, 0xF000F0));
             renderer.render(player, player.getX(), player.getY(), player.getZ(), 0.0F, matrixStack2, immediate, 0xF000F0);
         });
-        
+
         immediate.endBatch();
         renderer.setRenderShadow(true);
         matrixStack.popMatrix();
-        
+
         Lighting.setupFor3DItems();
     }
-    
+
     private void fixEntityRender(Entity entity, PoseStack matrixStack, Runnable runnable) {
         if (entity instanceof EnderDragon) {
             // dragon model is backwards, flip it
@@ -245,7 +245,7 @@ public class MobScreen extends OptionsSubScreen {
             runnable.run();
         }
     }
-    
+
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         if (super.mouseClicked(mouseX, mouseY, button)) {
@@ -257,7 +257,7 @@ public class MobScreen extends OptionsSubScreen {
         this.mouseDownY = mouseY;
         return false;
     }
-    
+
     @Override
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
         super.mouseReleased(mouseX, mouseY, button);
@@ -265,7 +265,7 @@ public class MobScreen extends OptionsSubScreen {
         this.mouseDownY = 0;
         return false;
     }
-    
+
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         if (super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY)) {
@@ -286,19 +286,19 @@ public class MobScreen extends OptionsSubScreen {
                 this.previewY += mouseY - this.mouseDownY;
             }
         }
-        
+
         this.mouseDownX = mouseX;
         this.mouseDownY = mouseY;
         return false;
     }
-    
+
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
         this.previewZoom += (float) verticalAmount;
         clampZoom();
         return true;
     }
-    
+
     @Override
     public void tick() {
         super.tick();
@@ -309,16 +309,16 @@ public class MobScreen extends OptionsSubScreen {
                 }
             });
         }
-        
+
         if (this.fakeEntity != null) {
             // tick entity
             this.fakeEntity.setOldPosAndRot();
             ++this.fakeEntity.tickCount;
             this.fakeEntity.tick();
-            
+
             // prevent some logic from running by faking first tick every tick
             ((AccessEntity) this.fakeEntity).setFirstTick(true);
-            
+
             // special cases that need to update every tick
             if (this.fakeEntity instanceof WaterAnimal waterCreature) {
                 // put water creatures in their natural habitat
@@ -334,13 +334,13 @@ public class MobScreen extends OptionsSubScreen {
                 ((AccessAbstractPiglin) piglin).setTimeInOverworld(-1);
             }
         }
-        
+
         if (this.fakePlayer != null) {
             // tick player
             this.fakePlayer.setOldPosAndRot();
             ++this.fakePlayer.tickCount;
             this.fakePlayer.rideTick();
-            
+
             // fix player yaw
             this.fakePlayer.setYRot(0);
             this.fakePlayer.yRotO = 0;
@@ -350,7 +350,7 @@ public class MobScreen extends OptionsSubScreen {
             this.fakePlayer.yHeadRotO = 0;
         }
     }
-    
+
     @Override
     public void onClose() {
         super.onClose();
@@ -359,7 +359,7 @@ public class MobScreen extends OptionsSubScreen {
             this.fakePlayer.stopRiding();
         }
     }
-    
+
     private void clampYawPitch() {
         if (this.previewPitch < -45.0) {
             this.previewPitch = -45.0F;
@@ -373,7 +373,7 @@ public class MobScreen extends OptionsSubScreen {
             this.previewYaw -= 360;
         }
     }
-    
+
     private void clampZoom() {
         if (this.previewZoom < 10.0F) {
             this.previewZoom = 10.0F;

--- a/src/main/java/org/purpurmc/purpur/client/gui/screen/MobScreen.java
+++ b/src/main/java/org/purpurmc/purpur/client/gui/screen/MobScreen.java
@@ -4,13 +4,30 @@ import com.mojang.blaze3d.platform.Lighting;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import java.util.List;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.options.OptionsSubScreen;
-import net.minecraft.client.renderer.CoreShaders;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.ambient.Bat;
+import net.minecraft.world.entity.animal.WaterAnimal;
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import net.minecraft.world.entity.boss.enderdragon.phases.EnderDragonPhase;
+import net.minecraft.world.entity.boss.wither.WitherBoss;
+import net.minecraft.world.entity.monster.Ghast;
+import net.minecraft.world.entity.monster.Giant;
+import net.minecraft.world.entity.monster.MagmaCube;
+import net.minecraft.world.entity.monster.Slime;
+import net.minecraft.world.entity.monster.Strider;
+import net.minecraft.world.entity.monster.hoglin.Hoglin;
+import net.minecraft.world.entity.monster.piglin.AbstractPiglin;
+import net.minecraft.world.entity.monster.warden.Warden;
 import org.joml.Matrix4fStack;
 import org.joml.Quaternionf;
 import org.purpurmc.purpur.client.PurpurClient;
@@ -27,27 +44,7 @@ import org.purpurmc.purpur.client.mixin.accessor.AccessMagmaCube;
 import org.purpurmc.purpur.client.mixin.accessor.AccessSlime;
 
 import java.util.ArrayList;
-
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.Renderable;
-import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.ambient.Bat;
-import net.minecraft.world.entity.animal.WaterAnimal;
-import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
-import net.minecraft.world.entity.boss.enderdragon.phases.EnderDragonPhase;
-import net.minecraft.world.entity.boss.wither.WitherBoss;
-import net.minecraft.world.entity.monster.Ghast;
-import net.minecraft.world.entity.monster.Giant;
-import net.minecraft.world.entity.monster.MagmaCube;
-import net.minecraft.world.entity.monster.Slime;
-import net.minecraft.world.entity.monster.Strider;
-import net.minecraft.world.entity.monster.hoglin.Hoglin;
-import net.minecraft.world.entity.monster.piglin.AbstractPiglin;
-import net.minecraft.world.entity.monster.warden.Warden;
+import java.util.List;
 
 public class MobScreen extends OptionsSubScreen {
     public static final Component TITLE = Component.translatable("purpurclient.options.title");
@@ -164,9 +161,7 @@ public class MobScreen extends OptionsSubScreen {
         } else {
             super.renderBlurredBackground();
         }
-        RenderSystem.setShader(CoreShaders.POSITION_TEX);
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-        RenderSystem.setShaderTexture(0, AbstractContainerScreen.INVENTORY_LOCATION);
 
         if (this.fakePlayer != null && this.fakeEntity != null) {
             drawPreviewModel(this.fakePlayer, this.fakeEntity);

--- a/src/main/java/org/purpurmc/purpur/client/gui/screen/widget/DoubleButton.java
+++ b/src/main/java/org/purpurmc/purpur/client/gui/screen/widget/DoubleButton.java
@@ -59,9 +59,7 @@ public class DoubleButton extends AbstractWidget implements Tickable {
     }
 
     private void drawButton(GuiGraphics context, Component text, int x, boolean i) {
-        RenderSystem.enableDepthTest();
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, this.alpha);
-        RenderSystem.enableBlend();
         context.blitSprite(RenderType::guiTextured, TEXTURES.get(this.active, i), x, this.getY(), this.height, this.height);
         context.drawCenteredString(Minecraft.getInstance().font, text, x + this.height / 2, this.getY() + (this.height - 8) / 2, (this.active ? 0xFFFFFF : 0xA0A0A0) | Mth.ceil(this.alpha * 255.0f) << 24);
     }

--- a/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
+++ b/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
@@ -1,12 +1,16 @@
 package org.purpurmc.purpur.client.mixin;
 
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.LoadingOverlay;
+import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
-
+import net.minecraft.server.packs.resources.ReloadInstance;
+import net.minecraft.util.Mth;
 import net.minecraft.util.TriState;
 import org.purpurmc.purpur.client.PurpurClient;
 import org.purpurmc.purpur.client.gui.SplashTexture;
@@ -21,13 +25,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import net.minecraft.Util;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screens.LoadingOverlay;
-import net.minecraft.server.packs.resources.ReloadInstance;
-import net.minecraft.util.Mth;
 
 @Mixin(LoadingOverlay.class)
 public abstract class MixinLoadingOverlay {
@@ -56,15 +53,10 @@ public abstract class MixinLoadingOverlay {
     @Unique
     private RenderType.CompositeRenderType PURPUR_LOGO = RenderType.create(
         "purpur_splash",
-        DefaultVertexFormat.POSITION_TEX_COLOR,
-        VertexFormat.Mode.QUADS,
         RenderType.SMALL_BUFFER_SIZE,
+        RenderPipelines.GUI_TEXTURED,
         RenderType.CompositeState.builder()
             .setTextureState(new RenderStateShard.TextureStateShard(SplashTexture.SPLASH, TriState.DEFAULT, false))
-            .setShaderState(RenderStateShard.POSITION_TEXTURE_COLOR_SHADER)
-            .setTransparencyState(RenderStateShard.TRANSLUCENT_TRANSPARENCY)
-            .setDepthTestState(RenderStateShard.NO_DEPTH_TEST)
-            .setWriteMaskState(RenderStateShard.COLOR_WRITE)
             .createCompositeState(false)
     );
 

--- a/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
+++ b/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
@@ -1,9 +1,5 @@
 package org.purpurmc.purpur.client.mixin;
 
-import net.minecraft.Util;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screens.LoadingOverlay;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
@@ -25,6 +21,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.LoadingOverlay;
 
 @Mixin(LoadingOverlay.class)
 public abstract class MixinLoadingOverlay {

--- a/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
+++ b/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
+
 import net.minecraft.util.TriState;
 import org.purpurmc.purpur.client.PurpurClient;
 import org.purpurmc.purpur.client.gui.SplashTexture;

--- a/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
+++ b/src/main/java/org/purpurmc/purpur/client/mixin/MixinLoadingOverlay.java
@@ -5,8 +5,6 @@ import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ReloadInstance;
-import net.minecraft.util.Mth;
 import net.minecraft.util.TriState;
 import org.purpurmc.purpur.client.PurpurClient;
 import org.purpurmc.purpur.client.gui.SplashTexture;
@@ -26,6 +24,8 @@ import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.LoadingOverlay;
+import net.minecraft.server.packs.resources.ReloadInstance;
+import net.minecraft.util.Mth;
 
 @Mixin(LoadingOverlay.class)
 public abstract class MixinLoadingOverlay {

--- a/src/main/java/org/purpurmc/purpur/client/mixin/mob/MixinSheep.java
+++ b/src/main/java/org/purpurmc/purpur/client/mixin/mob/MixinSheep.java
@@ -3,7 +3,7 @@ package org.purpurmc.purpur.client.mixin.mob;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.animal.Sheep;
+import net.minecraft.world.entity.animal.sheep.Sheep;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.purpurmc.purpur.client.entity.RidableEntity;

--- a/src/main/java/org/purpurmc/purpur/client/mixin/mob/MixinWolf.java
+++ b/src/main/java/org/purpurmc/purpur/client/mixin/mob/MixinWolf.java
@@ -3,7 +3,7 @@ package org.purpurmc.purpur.client.mixin.mob;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.animal.Wolf;
+import net.minecraft.world.entity.animal.wolf.Wolf;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.purpurmc.purpur.client.entity.RidableEntity;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,9 +28,9 @@
     "purpurclient.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.10",
+    "fabricloader": ">=0.16.10",
     "fabric": "*",
-    "minecraft": ">=1.21.5"
+    "minecraft": ">1.21.4"
   },
   "custom": {
     "modmenu": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
   "depends": {
     "fabricloader": ">=0.15.10",
     "fabric": "*",
-    "minecraft": ">=1.21.2"
+    "minecraft": ">=1.21.5"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
This PR updated to 1.21.5  

TODO:
- [x] Find cause of `OpenGL debug message: id=1282, source=API, type=ERROR, severity=HIGH, message='Error has been generated. GL error GL_INVALID_OPERATION in (null): (ID: 173538523) Generic error'` on integrated graphics and probably also on other cards. ~This is probably coming from Modmenu because the game crashes when interacting with anything from Modmenu.~ ~Not Modmenu related, occurs randomly~ Vanilla Minecraft has this bug
